### PR TITLE
Update address offset for game state and gauge percentage detection

### DIFF
--- a/Reflux/PlayData.cs
+++ b/Reflux/PlayData.cs
@@ -71,7 +71,7 @@ namespace Reflux
                 var song = Utils.ReadInt32(Offsets.PlayData, 0);
                 difficulty = (Difficulty)Utils.ReadInt32(Offsets.PlayData, word);
                 clearLamp = (Lamp)Utils.ReadInt32(Offsets.PlayData, word * 6);
-                gauge = Utils.ReadInt32(Offsets.PlayData, word * 8);
+                gauge = Utils.ReadInt32(Offsets.JudgeData, word * 82); /* It's not in the place near the play data */
 
                 songID = song.ToString("00000");
                 chart = FetchChartInfo(Utils.songDb[songID], difficulty);

--- a/Reflux/PlayData.cs
+++ b/Reflux/PlayData.cs
@@ -71,7 +71,9 @@ namespace Reflux
                 var song = Utils.ReadInt32(Offsets.PlayData, 0);
                 difficulty = (Difficulty)Utils.ReadInt32(Offsets.PlayData, word);
                 clearLamp = (Lamp)Utils.ReadInt32(Offsets.PlayData, word * 6);
-                gauge = Utils.ReadInt32(Offsets.JudgeData, word * 82); /* It's not in the place near the play data */
+                gauge = Utils.ReadInt32(Offsets.JudgeData, word * 81) + Utils.ReadInt32(Offsets.JudgeData, word * 82); /* It's not in the place near the play data
+                                                                                                                        * Since the gauge percent in judge data is separate for P1 and P2
+                                                                                                                        * they need to be merged */
 
                 songID = song.ToString("00000");
                 chart = FetchChartInfo(Utils.songDb[songID], difficulty);

--- a/Reflux/Utils.cs
+++ b/Reflux/Utils.cs
@@ -225,7 +225,7 @@ namespace Reflux
 
             /* Cannot go from song select to result screen anyway */
             if (currentState == GameState.songSelect) { return currentState; }
-            marker = ReadInt32(Offsets.PlaySettings - word * 5, 0);
+            marker = ReadInt32(Offsets.PlaySettings - word * 6, 0);
             if (marker == 1)
             {
                 return GameState.songSelect;


### PR DESCRIPTION
Similar to #21, but for fixing detection of song select state, and gauge percentage on result.

An interesting thing is that gauge percentage is no longer on an address near play data, and instead on an address somewhat far from judge data.
I tested gauge percentage address by playing a few song and searching address for result percentage, and this was the only address to contain this data.