### PR TITLE
Fixed a misscounts recording at the end of a song.

### DIFF
--- a/Reflux/Judge.cs
+++ b/Reflux/Judge.cs
@@ -38,8 +38,8 @@
             var p2fast = Utils.ReadInt32(Offsets.JudgeData, word * 13);
             var p1slow = Utils.ReadInt32(Offsets.JudgeData, word * 14);
             var p2slow = Utils.ReadInt32(Offsets.JudgeData, word * 15);
-            var measure_end = Utils.ReadInt32(Offsets.JudgeData, word * 16);
-
+            var p1measure_end = Utils.ReadInt32(Offsets.JudgeData, word * 16);
+            var p2measure_end = Utils.ReadInt32(Offsets.JudgeData, word * 17);
 
             if (p1pgreat + p1great + p1good + p1bad + p1poor == 0)
             {
@@ -59,7 +59,7 @@
             fast = p1fast + p2fast;
             slow = p1slow + p2slow;
             combobreak = p1cb + p2cb;
-            prematureEnd = measure_end != 0;
+            prematureEnd = p1measure_end + p2measure_end != 0;
         }
     }
 }

--- a/Reflux/PlayData.cs
+++ b/Reflux/PlayData.cs
@@ -39,7 +39,7 @@ namespace Reflux
         public uint MissCount { get { return (uint)(judges.bad + judges.poor); } }
         public int ExScore { get { return exscore; } }
         /// <summary>
-        /// Play ended prematurely (Quit or failed HC/EXH)
+        /// Play ended prematurely (Quit or failed HC/EXH or 50 consecutive misses in Normal Gauge)
         /// </summary>
         public bool PrematureEnd { get { return judges.prematureEnd; } }
         /// <summary>

--- a/Reflux/PlayData.cs
+++ b/Reflux/PlayData.cs
@@ -46,6 +46,7 @@ namespace Reflux
         /// True if miss count shouldn't be calculated and saved (When it's not shown in the result screens essentially)
         /// </summary>
         public bool MissCountValid { get { return (DataAvailable && !PrematureEnd && settings.assist == "OFF"); } }
+        public string Gauge { get { return settings.gauge; } }
 
         public PlayData()
         {

--- a/Reflux/Program.cs
+++ b/Reflux/Program.cs
@@ -340,7 +340,10 @@ namespace Reflux
                                             var entry = Tracker.trackerDb[c];
                                             entry.grade = (Grade)Math.Max((int)entry.grade, (int)latestData.Grade);
                                             entry.lamp = (Lamp)Math.Max((int)entry.lamp, (int)latestData.Lamp);
-                                            entry.misscount = Math.Min(entry.misscount, latestData.MissCount);
+                                            if (!latestData.PrematureEnd && (latestData.Lamp != Lamp.F || (latestData.Lamp == Lamp.F && !latestData.Gauge.Contains("HARD"))))
+                                            {
+                                                entry.misscount = Math.Min(entry.misscount, latestData.MissCount);
+                                            }
                                             entry.ex_score = Math.Max(entry.ex_score, latestData.ExScore);
                                             Tracker.trackerDb[c] = entry;
                                             Tracker.SaveTracker();


### PR DESCRIPTION
Since misscounts at the end of a song is always recorded, so it will be recorded even if you fail to play.
Therefore, we have made a correction so that a misscounts will not be recorded in the following cases:

- if the song is forced to end.
- if the song ends midway in hard gauge
- 50 consecutive misses in normal gauge.

Also, since 'measure_end' only reflected 1P, I changed it to read 2P as well.